### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## 安裝套件
 
 ### 安裝 [Python](https://www.python.org/) 或是 [Anaconda](https://anaconda.org/)
-安裝時我是把 "Add Pytho 3.6 to path" 項目打開， 讓 windows command prompt 可以直接使用 python
+安裝時我是把 "Add Python 3.6 to path" 項目打開， 讓 windows command prompt 可以直接使用 python
 你可以使用 --version 的參數來知道 python 的版本
 >python --version
 


### PR DESCRIPTION
## Summary
- correct "Add Python" path instruction in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cdf1952e88323aa0068766919754e